### PR TITLE
feat: add `loading="lazy"` attribute to all `<img>` tags

### DIFF
--- a/templates/stripes/stripe-contact.php
+++ b/templates/stripes/stripe-contact.php
@@ -6,6 +6,7 @@
                 <img
                     src="<?= $this->image($headshot, !empty($image_style) ? $image_style : 'headshot') ?>"
                     alt="Contact Headshot"
+                    loading="lazy"
                 />
             </div>
             <?php endif; ?>

--- a/templates/stripes/stripe-gallery.php
+++ b/templates/stripes/stripe-gallery.php
@@ -17,6 +17,7 @@ $slides = array_values(array_filter($slides, function ($slide) {
                                 ? htmlspecialchars(strip_tags($slide['alt']['html']), ENT_QUOTES, 'UTF-8')
                                 : ''
                             ?>"
+                            loading="lazy"
                         />
                     </div>
                     <?php if (!empty($slide['caption']['html']) || !empty($slide['credit']['html']) || count($slides) > 1) : ?>

--- a/templates/stripes/stripe-googlemap.php
+++ b/templates/stripes/stripe-googlemap.php
@@ -1,43 +1,41 @@
 <?php if ($address): ?>
 <div class="<?= $this->e($type, 'wrapperClasses') ?>">
-  <div class="vssl-stripe-column">
-    <div class="vssl-stripe--googlemap--embed"
-      <?php if (isset($options['styles'])): ?>
-      data-styles="<?= $this->inlineJson($options['styles']) ?>"
-      <?php endif; ?>
-      <?php if (isset($options['marker'])): ?>
-      data-marker="<?= $options['marker'] ?>"
-      <?php endif; ?>
-      <?php if (isset($coordinates)): ?>
-      data-coordinates="<?= $this->inlineJson($coordinates) ?>"
-      <?php endif; ?>
-      <?php if (isset($address)): ?>
-      data-location="<?= $address ?>"
-      <?php endif; ?>
-      data-maptype="<?= isset($maptype) ? $maptype : 'roadmap' ?>"
-      data-zoom="<?= $zoom ?>"
-    >
-      <div id="map-<?= $weight ?>" class="vssl-stripe--googlemap--map">
-        <!-- JS-loaded map goes here -->
-        <noscript>
-          <div>You must enable JavaScript to load this map.</div>
-        </noscript>
-      </div>
-      <div class="custom-controls">
-        <div class="address">
-          <?= $address ?>
+    <div class="vssl-stripe-column">
+        <div class="vssl-stripe--googlemap--embed"
+            <?php if (isset($options['styles'])): ?>
+            data-styles="<?= $this->inlineJson($options['styles']) ?>"
+            <?php endif; ?>
+            <?php if (isset($options['marker'])): ?>
+            data-marker="<?= $options['marker'] ?>"
+            <?php endif; ?>
+            <?php if (isset($coordinates)): ?>
+            data-coordinates="<?= $this->inlineJson($coordinates) ?>"
+            <?php endif; ?>
+            <?php if (isset($address)): ?>
+            data-location="<?= $address ?>"
+            <?php endif; ?>
+            data-maptype="<?= isset($maptype) ? $maptype : 'roadmap' ?>"
+            data-zoom="<?= $zoom ?>"
+        >
+            <div id="map-<?= $weight ?>" class="vssl-stripe--googlemap--map">
+                <!-- JS-loaded map goes here -->
+                <noscript>
+                    <div>You must enable JavaScript to load this map.</div>
+                </noscript>
+            </div>
+            <div class="custom-controls">
+                <div class="address"><?= $address ?></div>
+                <div class="navigate">
+                    <a class="navigate-link" href="<?= $navigationUrl ?>" target="_blank">
+                        <div class="icon navigate-icon"></div>
+                        <div class="navigate-text">Directions</div>
+                    </a>
+                </div>
+                <div class="google-maps-link">
+                    <a href="<?= $largerUrl ?>" target="_blank">View larger map</a>
+                </div>
+            </div>
         </div>
-        <div class="navigate">
-          <a class="navigate-link" href="<?= $navigationUrl ?>" target="_blank">
-            <div class="icon navigate-icon"></div>
-            <div class="navigate-text">Directions</div>
-          </a>
-        </div>
-        <div class="google-maps-link">
-          <a href="<?= $largerUrl ?>" target="_blank">View larger map</a>
-        </div>
-      </div>
     </div>
-  </div>
 </div>
 <?php endif; ?>

--- a/templates/stripes/stripe-infographic.php
+++ b/templates/stripes/stripe-infographic.php
@@ -9,7 +9,11 @@
         <?php endif; ?>
 
         <div class="vssl-stripe--infographic--image">
-            <img src="<?= $this->image($image, !empty($image_style) ? $image_style : null) ?>" alt="<?= $image ?>" />
+            <img
+                src="<?= $this->image($image, !empty($image_style) ? $image_style : null) ?>"
+                alt="<?= $image ?>"
+                loading="lazy"
+            />
         </div>
         <?php if (!empty($caption['html']) || !empty($credit['html'])) : ?>
         <div class="vssl-stripe--infographic--meta">

--- a/templates/stripes/stripe-link.php
+++ b/templates/stripes/stripe-link.php
@@ -18,6 +18,7 @@
                             ? htmlspecialchars(strip_tags($alt['html']), ENT_QUOTES, 'UTF-8')
                             : (!empty($alt) && is_string($alt) ? $alt : '')
                     ?>"
+                    loading="lazy"
                 />
             </div>
             <?php endif; ?>

--- a/templates/stripes/stripe-related.php
+++ b/templates/stripes/stripe-related.php
@@ -18,6 +18,7 @@ $links = array_values(array_filter($links, function ($link) {
                             class="vssl-stripe--related--thumbnail"
                             src="<?= $this->image($link['page']['image'], !empty($image_style) ? $image_style : null) ?>"
                             alt="<?= $link['page']['image'] ?>"
+                            loading="lazy"
                         />
                         <?php endif; ?>
 

--- a/templates/stripes/stripe-text-image.php
+++ b/templates/stripes/stripe-text-image.php
@@ -1,10 +1,14 @@
 <?php if (!empty($image)) : ?>
 <div class="<?= $this->e($type, 'wrapperClasses') ?>">
-  <div class="vssl-stripe-column<?= ($layout == 'image-left') ? ' image-left' : '' ?>">
-    <div class="vssl-stripe--text-image--text"><?= $text['html'] ?></div>
-    <div class="vssl-stripe--text-image--image">
-        <img src="<?= $this->image($image, !empty($image_style) ? $image_style : null) ?>" alt="<?= $image ?>" />
+    <div class="vssl-stripe-column<?= ($layout == 'image-left') ? ' image-left' : '' ?>">
+        <div class="vssl-stripe--text-image--text"><?= $text['html'] ?></div>
+        <div class="vssl-stripe--text-image--image">
+            <img
+              src="<?= $this->image($image, !empty($image_style) ? $image_style : null) ?>"
+              alt="<?= $image ?>"
+              loading="lazy"
+            />
+        </div>
     </div>
-  </div>
 </div>
 <?php endif; ?>


### PR DESCRIPTION
Defer image loading to prioritize other critical assets (like the Vessel page editor).

Could conditionally include the attribute ONLY if the stripe is not sticky. What do you think?