### PR TITLE
Table of Contents Stripe

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -265,22 +265,24 @@ class Renderer
      *
      * @return string
      */
-    public function tableOfContents()
+    public function tableOfContents($scope)
     {
         if (empty($this->data['stripes'])) return '';
 
         $stripes = $this->data['stripes'];
-        $items = array_map(function ($stripe, $index) {
+        $items = array_map(function ($stripe, $index) use ($scope) {
             if (
-                $stripe['type'] === 'stripe-break'
-                && !empty($stripe['heading']['html'])
+                (empty($scope) || strpos($scope, 'break') !== false) &&
+                $stripe['type'] === 'stripe-break' &&
+                !empty($stripe['heading']['html'])
             ) {
                 $content = $stripe['heading']['html'];
                 return $this->getBreakStripeTableItems($content, $index);
             }
             if (
-                $stripe['type'] === 'stripe-textblock'
-                && !empty($stripe['content']['html'])
+                (empty($scope) || strpos($scope, 'textblock') !== false) &&
+                $stripe['type'] === 'stripe-textblock' &&
+                !empty($stripe['content']['html'])
             ) {
                 $content = $stripe['content']['html'];
                 return $this->getTextblockStripeTableItems($content, $index);

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -221,12 +221,14 @@ class Renderer
         if (empty($stripe['heading']['html'])) {
             return null;
         } else {
-            $stripeId = $stripe['id'] ?? 0;
-            return [
+            $heading = [
                 'level' => 1,
                 'headingText' => strip_tags($stripe['heading']['html']),
-                'id' => "vssl-stripe--break-$stripeId--heading"
             ];
+            if (!empty($stripe['heading_id'])) {
+                $heading['id'] = $stripe['heading_id'];
+            }
+            return $heading;
         }
     }
 
@@ -243,29 +245,30 @@ class Renderer
             return null;
         }
 
-        $stripeId = $stripe['id'] ?? 0;
         $dom = new DOMDocument();
         $dom->loadHTML($stripe['content']['html']);
         $xpath = new DOMXPath($dom);
-        $headers = $xpath->query('//h1 | //h2');
+        $headings = $xpath->query('//h1 | //h2');
 
         $listItems = [];
         $h1Count = 0;
         $h2Count = 0;
-        foreach ($headers as $header) {
-            $tagName = $header->tagName;
-            $prefix = "vssl-stripe--textblock-$stripeId--heading";
-            $headerIndex = $tagName === 'h1' ? $h1Count : $h2Count;
-            $id = $prefix . '-' . $tagName . '-' . $headerIndex;
+        foreach ($headings as $heading) {
+            $listItem = [
+                'level' => $heading->tagName === 'h1' ? 1 : 2,
+                'headingText' => $heading->nodeValue,
+            ];
+            if (!empty($heading->id)) {
+                $listItem['id'] = $heading->id;
+            }
 
-            array_push($listItems, [
-                'level' => $tagName === 'h1' ? 1 : 2,
-                'headingText' => $header->nodeValue,
-                'id' => $id
-            ]);
+            array_push($listItems, $listItem);
 
-            if ($tagName === 'h1') $h1Count++;
-            else $h2Count++;
+            if ($heading->tagName === 'h1') {
+                $h1Count++;
+            } else {
+                $h2Count++;
+            }
         }
         return $listItems;
     }

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -217,14 +217,15 @@ class Renderer
      * @return array
      *
      */
-    private function getBreakStripeHeading($stripe, $index) {
+    private function getBreakStripeHeading($stripe) {
         if (empty($stripe['heading']['html'])) {
             return null;
         } else {
+            $stripeId = $stripe['id'] ?? 0;
             return [
                 'level' => 1,
                 'headingText' => strip_tags($stripe['heading']['html']),
-                'id' => 'vssl-stripe--break--heading-' . $index
+                'id' => "vssl-stripe--break-$stripeId--heading"
             ];
         }
     }
@@ -237,11 +238,12 @@ class Renderer
      * @return array
      *
      */
-    private function getTextblockStripeHeadings($stripe, $index) {
+    private function getTextblockStripeHeadings($stripe) {
         if (empty($stripe['content']['html'])) {
             return null;
         }
 
+        $stripeId = $stripe['id'] ?? 0;
         $dom = new DOMDocument();
         $dom->loadHTML($stripe['content']['html']);
         $xpath = new DOMXPath($dom);
@@ -252,9 +254,9 @@ class Renderer
         $h2Count = 0;
         foreach ($headers as $header) {
             $tagName = $header->tagName;
-            $prefix = 'vssl-stripe--textblock--heading-';
+            $prefix = "vssl-stripe--textblock-$stripeId--heading";
             $headerIndex = $tagName === 'h1' ? $h1Count : $h2Count;
-            $id = $prefix . $index . '-' . $tagName . '-' . $headerIndex;
+            $id = $prefix . '-' . $tagName . '-' . $headerIndex;
 
             array_push($listItems, [
                 'level' => $tagName === 'h1' ? 1 : 2,
@@ -288,7 +290,7 @@ class Renderer
             }
 
             if ($stripe['type'] === 'stripe-textblock' && $inScope('textblock')) {
-                array_push($items, ...$this->getTextblockStripeHeadings($stripe, $index));
+                array_push($items, ...$this->getTextblockStripeHeadings($stripe));
             }
         };
 
@@ -329,32 +331,6 @@ class Renderer
         }
 
         return $data;
-    }
-
-    /**
-     * Process stripe-textblock data
-     *
-     * @param  array $stripe array of data
-     * @return array
-     */
-    public function processStripeTextblock($stripe, $stripeIndex)
-    {
-        if (!empty($stripe['content']['html'])) {
-            // Add a unique id to each h1 and h2 tag so they can be anchored to
-            $dom = new DOMDocument();
-            $dom->loadHTML($stripe['content']['html']);
-            foreach (['h1', 'h2'] as $tagName) {
-                $headers = $dom->getElementsByTagName($tagName);
-                foreach ($headers as $index => $header) {
-                    $prefix = 'vssl-stripe--textblock--heading-';
-                    $id = $prefix . $stripeIndex . '-' . $tagName . '-' . $index;
-                    $header->setAttribute('id', $id);
-                }
-            }
-            $stripe['content']['html'] = $dom->saveHTML();
-        }
-
-        return $stripe;
     }
 
     /**

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -216,12 +216,12 @@ class Renderer
      */
     public function tableOfContents()
     {
-        if (!isset($this->data['stripes'])) return '';
+        if (empty($this->data['stripes'])) return '';
 
         $stripes = $this->data['stripes'];
         $filtered = array_filter($stripes, function ($s) {
-            return ($s['type'] === 'stripe-break' && $s['heading']['html'])
-                || ($s['type'] === 'stripe-textblock' && $s['content']['html']);
+            return ($s['type'] === 'stripe-break' && !empty($s['heading']['html']))
+                || ($s['type'] === 'stripe-textblock' && !empty($s['content']['html']));
         });
 
         $items = array_map(function ($s) {
@@ -249,25 +249,7 @@ class Renderer
 
         $flatItems = array_merge(...array_filter($items, fn($i) => $i !== NULL));
 
-        $i = 0;
-        $listHtml = "<ul>";
-        while ($i < count($flatItems)) {
-            $item = $flatItems[$i];
-            if ($item['level'] === 1) {
-                $listHtml .= "<li>{$item['text']}</li>";
-                $i++;
-                continue;
-            } else if ($item['level'] === 2) {
-                $listHtml .= "<ul>";
-            }
-            while ($item['level'] === 2) {
-                $listHtml .= "<li>{$item['text']}</li>";
-                $i++;
-                $item = $flatItems[$i];
-            }
-            $listHtml .= "</ul>";
-        }
-        return $listHtml . "</ul>";
+        return $flatItems;
     }
 
     /**

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -279,25 +279,20 @@ class Renderer
             return null;
         }
 
+        $items = [];
         $stripes = $this->data['stripes'];
-        $items = array_map(function ($stripe, $index) use ($scope) {
-            if (
-                (empty($scope) || strpos($scope, 'break') !== false) &&
-                $stripe['type'] === 'stripe-break'
-            ) {
-                return [$this->getBreakStripeHeading($stripe, $index)];
+        $inScope = fn($type) => empty($scope) || in_array($type, $scope);
+        foreach ($stripes as $index => $stripe) {
+            if ($stripe['type'] === 'stripe-break' && $inScope('break')) {
+                array_push($items, $this->getBreakStripeHeading($stripe, $index));
             }
-            if (
-                (empty($scope) || strpos($scope, 'textblock') !== false) &&
-                $stripe['type'] === 'stripe-textblock'
-            ) {
-                return $this->getTextblockStripeHeadings($stripe, $index);
+
+            if ($stripe['type'] === 'stripe-textblock' && $inScope('textblock')) {
+                array_push($items, ...$this->getTextblockStripeHeadings($stripe, $index));
             }
-        }, $stripes, array_keys($stripes));
+        };
 
-        $flatItems = array_merge(...array_filter($items));
-
-        return $flatItems;
+        return $items;
     }
 
     /**

--- a/templates/page.php
+++ b/templates/page.php
@@ -1,8 +1,9 @@
 <div class="vssl-page" data-id="<?= $this->e($id) ?>" data-type="<?= $this->e($type) ?>">
     <?php if ($stripes) : ?>
     <div class="vssl-stripes">
-        <?php foreach ($stripes as $stripe) : ?>
-        <?= $this->insert($themePrefix . 'stripes/' . $stripe['type'], $stripe) ?>
+        <?php foreach ($stripes as $index => $stripe) : ?>
+            <?php $stripe['stripe_index'] = $index; ?>
+            <?= $this->insert($themePrefix . 'stripes/' . $stripe['type'], $stripe) ?>
         <?php endforeach; ?>
     </div>
     <?php endif; ?>

--- a/templates/stripes/stripe-break.php
+++ b/templates/stripes/stripe-break.php
@@ -1,14 +1,17 @@
+<?php $tag = !empty($heading_tag) ? $heading_tag : 'h2' ?>
+
 <div class="<?= $this->e($type, 'wrapperClasses') ?>">
     <div class="vssl-stripe-column">
         <hr />
 
         <?php if (!empty($heading['html'])) : ?>
-        <<?= !empty($heading_tag) ? $heading_tag : 'h2' ?>
+        <<?= $tag ?>
+            id="vssl-stripe--break--heading-<?= $stripe_index ?>"
             class="vssl-stripe--break--heading"
             data-heading="<?= strip_tags($heading['html']) ?>"
-        ><?=
-            $this->inline($heading['html'])
-        ?></<?= !empty($heading_tag) ? $heading_tag : 'h2' ?>>
+        >
+            <?= $this->inline($heading['html'])?>
+        </<?= $tag ?>>
         <?php endif; ?>
     </div>
 </div>

--- a/templates/stripes/stripe-break.php
+++ b/templates/stripes/stripe-break.php
@@ -6,7 +6,9 @@
 
         <?php if (!empty($heading['html'])) : ?>
         <<?= $tag ?>
+            <?php if (!empty($heading_id)) : ?>
             id="<?= $heading_id ?>"
+            <?php endif; ?>
             class="vssl-stripe--break--heading"
             data-heading="<?= strip_tags($heading['html']) ?>"
         >

--- a/templates/stripes/stripe-break.php
+++ b/templates/stripes/stripe-break.php
@@ -6,7 +6,7 @@
 
         <?php if (!empty($heading['html'])) : ?>
         <<?= $tag ?>
-            id="vssl-stripe--break--heading-<?= $stripe_index ?>"
+            id="<?= $heading_id ?>"
             class="vssl-stripe--break--heading"
             data-heading="<?= strip_tags($heading['html']) ?>"
         >

--- a/templates/stripes/stripe-toc.php
+++ b/templates/stripes/stripe-toc.php
@@ -1,12 +1,12 @@
-<?php $toc = $this->tableOfContents($scope) ?>
+<?php $toc = $this->getTableOfContents($scope) ?>
 
 <?php if (!empty($toc)) : ?>
 <div class="<?= $this->e($type, 'wrapperClasses') ?>">
   <div class="vssl-stripe-column">
     <div class="vssl-stripe--card">
-      <?php if (!empty($title['html'])) : ?>
-        <div class="vssl-stripe--toc--title"><?= $this->inline($title['html']) ?></div>
-      <?php endif; ?>
+      <div class="vssl-stripe--toc--title">
+        <?= $this->inline(empty($title['html']) ? 'Table of Contents' : $title['html']) ?>
+      </div>
 
       <?php foreach ($toc as $i => $item) : ?>
 
@@ -16,7 +16,7 @@
 
           <li>
             <a href="#<?= $item['id'] ?>">
-              <?= $item['text'] ?>
+              <?= $item['headingText'] ?>
             </a>
           </li>
 

--- a/templates/stripes/stripe-toc.php
+++ b/templates/stripes/stripe-toc.php
@@ -4,7 +4,10 @@
 <div class="<?= $this->e($type, 'wrapperClasses') ?>">
   <div class="vssl-stripe-column">
     <div class="vssl-stripe--card">
-      <div class="vssl-stripe--toc--title">Table of Contents</div>
+      <?php if (!empty($title['html'])) : ?>
+        <div class="vssl-stripe--toc--title"><?= $this->inline($title['html']) ?></div>
+      <?php endif; ?>
+
       <?php foreach ($toc as $i => $item) : ?>
 
         <?php if ($i === 0 || $toc[$i - 1]['level'] < $item['level']) : ?>

--- a/templates/stripes/stripe-toc.php
+++ b/templates/stripes/stripe-toc.php
@@ -1,4 +1,4 @@
-<?php $toc = $this->tableOfContents() ?>
+<?php $toc = $this->tableOfContents($scope) ?>
 
 <?php if (!empty($toc)) : ?>
 <div class="<?= $this->e($type, 'wrapperClasses') ?>">

--- a/templates/stripes/stripe-toc.php
+++ b/templates/stripes/stripe-toc.php
@@ -14,13 +14,17 @@
         <ul>
         <?php endif ?>
 
-          <li><?= $item['text'] ?></li>
+          <li>
+            <a href="#<?= $item['id'] ?>">
+              <?= $item['text'] ?>
+            </a>
+          </li>
 
         <?php if ($i === count($toc) - 1 || $toc[$i + 1]['level'] < $item['level']) : ?>
         </ul>
         <?php endif ?>
 
-        <?php endforeach ?>
+      <?php endforeach ?>
     </div>
   </div>
 </div>

--- a/templates/stripes/stripe-toc.php
+++ b/templates/stripes/stripe-toc.php
@@ -15,7 +15,7 @@
         <?php endif ?>
 
           <li>
-            <a href="#<?= $item['id'] ?>">
+            <a href="#<?= empty($item['id']) ? '' : $item['id'] ?>">
               <?= $item['headingText'] ?>
             </a>
           </li>

--- a/templates/stripes/stripe-toc.php
+++ b/templates/stripes/stripe-toc.php
@@ -1,0 +1,8 @@
+<div class="<?= $this->e($type, 'wrapperClasses') ?>">
+  <div class="vssl-stripe-column">
+    <div class="vssl-stripe--card">
+      <div class="vssl-stripe--toc--title">Table of Contents</div>
+      <?= $this->tableOfContents() ?>
+    </div>
+  </div>
+</div>

--- a/templates/stripes/stripe-toc.php
+++ b/templates/stripes/stripe-toc.php
@@ -1,8 +1,24 @@
+<?php $toc = $this->tableOfContents() ?>
+
+<?php if (!empty($toc)) : ?>
 <div class="<?= $this->e($type, 'wrapperClasses') ?>">
   <div class="vssl-stripe-column">
     <div class="vssl-stripe--card">
       <div class="vssl-stripe--toc--title">Table of Contents</div>
-      <?= $this->tableOfContents() ?>
+      <?php foreach ($toc as $i => $item) : ?>
+
+        <?php if ($i === 0 || $toc[$i - 1]['level'] < $item['level']) : ?>
+        <ul>
+        <?php endif ?>
+
+          <li><?= $item['text'] ?></li>
+
+        <?php if ($i === count($toc) - 1 || $toc[$i + 1]['level'] < $item['level']) : ?>
+        </ul>
+        <?php endif ?>
+
+        <?php endforeach ?>
     </div>
   </div>
 </div>
+<?php endif ?>


### PR DESCRIPTION
# Table of Contents Stripe
Updated to include a new Table of Contents stripe (`./templates/stripes/stripe-toc.php`), which will dynamically render a list of items based on any headings in other break or textblock stripes on the same page. 
- The stripe can be configured to show a custom title ("Table of Contents" by default). 
- The stripe can be configured not include headings from either break stripes or textblock stripes (and the organization config can specify whether this options is available)
 
<img width="1327" alt="image" src="https://github.com/vssl/render/assets/10877197/0a8c09a7-a11e-467f-a9a8-40c313b99e20">

In this PR:
- **add a basic table on contents that renders dynamically based on h tags in textblock and break stripes**
- **update to do more rendering in the actual template**
- **render title inline if there is one**
- **render headers in textblocks and break stripes with unique ids**
- **include headings from stripes based on configuration**
