### PR TITLE
Gallery Stripe selected slide fix

### DIFF
--- a/templates/stripes/stripe-gallery.php
+++ b/templates/stripes/stripe-gallery.php
@@ -25,7 +25,7 @@ $slides = array_values(array_filter($slides, function ($slide) {
                         <?php if (!empty($slide['caption']['html'])) : ?>
                         <div class="vssl-stripe--gallery--caption"><?= $this->inline($slide['caption']['html']) ?></div>
                         <?php endif; ?>
-                        
+
                         <?php if (!empty($slide['credit']['html'])) : ?>
                         <div class="vssl-stripe--gallery--credit"><?= $this->inline($slide['credit']['html']) ?></div>
                         <?php endif; ?>
@@ -34,7 +34,44 @@ $slides = array_values(array_filter($slides, function ($slide) {
                 </div>
                 <?php endforeach; ?>
             </div>
+            <div
+                class="vssl-stripe--gallery--controls"
+                style="height: 0px; padding-bottom: 100%;"
+            >
+                <div class="vssl-stripe--gallery--buttons">
+                    <div class="vssl-stripe--gallery--button vssl-stripe--gallery--next"></div>
+                    <div class="vssl-stripe--gallery--button vssl-stripe--gallery--prev"></div>
+                </div>
+                <div class="vssl-stripe--gallery--counter">
+                    <span class="vssl-stripe--gallery--current">1</span>
+                    <span class="vssl-stripe--gallery--of">/</span>
+                    <span class="vssl-stripe--gallery--total"><?= count($slides) ?></span>
+                </div>
+            </div>
         </div>
     </div>
 </div>
+<script>
+const galleryEl = document.currentScript.previousElementSibling
+const nextBtn = galleryEl.querySelector('.vssl-stripe--gallery--next')
+const prevBtn = galleryEl.querySelector('.vssl-stripe--gallery--prev')
+const currentCounter = galleryEl.querySelector('.vssl-stripe--gallery--current')
+const slideEls = galleryEl.querySelectorAll('.vssl-stripe--gallery--slide')
+
+let slideIndex = 0
+const slideCount = slideEls.length
+function moveGallery(next = true) {
+    const prevIndex = slideIndex;
+    slideIndex = next ? slideIndex + 1 : slideIndex - 1
+    if (slideIndex >= slideCount) slideIndex = 0
+    else if (slideIndex < 0) slideIndex = slideCount - 1
+    slideEls[slideIndex].dataset.active = true
+    slideEls[prevIndex].dataset.active = false
+    currentCounter.innerHTML = slideIndex + 1
+}
+
+nextBtn.addEventListener('click', () => moveGallery(true))
+prevBtn.addEventListener('click', () => moveGallery(false))
+</script>
+
 <?php endif; ?>

--- a/templates/stripes/stripe-gallery.php
+++ b/templates/stripes/stripe-gallery.php
@@ -34,6 +34,7 @@ $slides = array_values(array_filter($slides, function ($slide) {
                 </div>
                 <?php endforeach; ?>
             </div>
+            <?php if (count($slides) > 1) : ?>
             <div
                 class="vssl-stripe--gallery--controls"
                 style="height: 0px; padding-bottom: 100%;"
@@ -48,9 +49,11 @@ $slides = array_values(array_filter($slides, function ($slide) {
                     <span class="vssl-stripe--gallery--total"><?= count($slides) ?></span>
                 </div>
             </div>
+            <?php endif; ?>
         </div>
     </div>
 </div>
+<?php if (count($slides) > 1) : ?>
 <script>
 const galleryEl = document.currentScript.previousElementSibling
 const nextBtn = galleryEl.querySelector('.vssl-stripe--gallery--next')
@@ -80,5 +83,6 @@ setSlideIndex(0)
 nextBtn.addEventListener('click', () => setSlideIndex(slideIndex + 1))
 prevBtn.addEventListener('click', () => setSlideIndex(slideIndex - 1))
 </script>
+<?php endif; ?>
 
 <?php endif; ?>

--- a/templates/stripes/stripe-gallery.php
+++ b/templates/stripes/stripe-gallery.php
@@ -60,18 +60,25 @@ const slideEls = galleryEl.querySelectorAll('.vssl-stripe--gallery--slide')
 
 let slideIndex = 0
 const slideCount = slideEls.length
-function moveGallery(next = true) {
-    const prevIndex = slideIndex;
-    slideIndex = next ? slideIndex + 1 : slideIndex - 1
+function setSlideIndex(index) {
+    slideIndex = index
     if (slideIndex >= slideCount) slideIndex = 0
     else if (slideIndex < 0) slideIndex = slideCount - 1
+
     slideEls[slideIndex].dataset.active = true
-    slideEls[prevIndex].dataset.active = false
     currentCounter.innerHTML = slideIndex + 1
+
+    nextSlideIndex = slideIndex + 1 === slideCount ? 0 : slideIndex + 1
+    prevSlideIndex = slideIndex === 0 ? slideCount - 1 : slideIndex - 1
+    slideEls[nextSlideIndex].querySelector('img').removeAttribute('loading')
+    slideEls[prevSlideIndex].querySelector('img').removeAttribute('loading')
+    slideEls[nextSlideIndex].dataset.active = false
+    slideEls[prevSlideIndex].dataset.active = false
 }
 
-nextBtn.addEventListener('click', () => moveGallery(true))
-prevBtn.addEventListener('click', () => moveGallery(false))
+setSlideIndex(0)
+nextBtn.addEventListener('click', () => setSlideIndex(slideIndex + 1))
+prevBtn.addEventListener('click', () => setSlideIndex(slideIndex - 1))
 </script>
 
 <?php endif; ?>


### PR DESCRIPTION
# Gallery Stripe: selected slide fix

- previously, the template for gallery stripe assumed a jquery script was being loaded on the page to provide controls UI and interactivity for navigating through the gallery of images 
- that script is no longer being used, so I added a small vanilla js script alongside the gallery stripe template itself to provide the same controls 
<img width="823" alt="image" src="https://github.com/vssl/render/assets/10877197/af173450-e6e3-4a69-b926-52144c6aa302">
