### PR TITLE
Infographic Stripe: enlarge fix

### DIFF
--- a/templates/stripes/stripe-infographic.php
+++ b/templates/stripes/stripe-infographic.php
@@ -20,7 +20,7 @@
             <?php if (!empty($caption['html'])) : ?>
             <div class="vssl-stripe--infographic--caption"><?= $this->inline($caption['html']) ?></div>
             <?php endif; ?>
-            
+
             <?php if (!empty($credit['html'])) : ?>
             <div class="vssl-stripe--infographic--credit"><?= $this->inline($credit['html']) ?></div>
             <?php endif; ?>
@@ -33,5 +33,39 @@
         </div>
         <?php endif; ?>
     </div>
+    <div class="vssl-stripe--infographic--lightbox">
+        <div class="vssl-stripe--infographic--image">
+            <img
+                src="<?= $this->image($image, !empty($image_style) ? $image_style : null) ?>"
+                alt="<?= $image ?>"
+                loading="lazy"
+            />
+        </div>
+        <button type="button" class="vssl-stripe--infographic--collapse">Close</button>
+    </div>
 </div>
+<script>
+const infographicEl = document.currentScript.previousElementSibling
+const enlargener = infographicEl.querySelector('.vssl-stripe--infographic--enlarge')
+const collapser = infographicEl.querySelector('.vssl-stripe--infographic--collapse')
+
+function onEnlarge() {
+    infographicEl.setAttribute('data-is-enlarged', true)
+    document.documentElement.classList.add('vssl-scroll-lock')
+    document.body.addEventListener('keyup', onInfographicKeyup)
+}
+
+function onCollapse() {
+    infographicEl.removeAttribute('data-is-enlarged')
+    document.documentElement.classList.remove('vssl-scroll-lock')
+    document.body.removeEventListener('keyup', onInfographicKeyup)
+}
+
+function onInfographicKeyup(e) {
+    if (e.key === 'Escape') onCollapse()
+}
+
+enlargener.addEventListener('click', onEnlarge)
+collapser.addEventListener('click', onCollapse)
+</script>
 <?php endif; ?>


### PR DESCRIPTION
Infographic Stripe: enlarge fix
- previously, the template for the infographic stripe assumed a jquery script was being loaded on the page to provide controls UI and interactivity for enlarging the contained image to fullscreen and locking the page scroll until the enlarged image was closed
- that script is no longer being used, so I added a small vanilla js script alongside the infographic stripe template itself to provide the same controls / functionality

<img width="1127" alt="image" src="https://github.com/vssl/render/assets/10877197/78465925-4b4e-4eb5-9376-8298bf820ee7">
