### PR TITLE
Google Maps Stripe: Fix broken implementation

### DIFF
--- a/templates/stripes/stripe-googlemap.php
+++ b/templates/stripes/stripe-googlemap.php
@@ -37,16 +37,16 @@ if (typeof google !== 'undefined') {
 }
 
 function initStripe() {
-    const marker = <?= isset($options['marker']) ? "'" . $options['marker'] . "'" : 'false' ?>
+    const marker = <?= !empty($options['marker']) ? "'" . $options['marker'] . "'" : 'false' ?>
 
-    const coordinates = <?= isset($options['coordinates']) ? "'" . $options['coordinates'] . "'" : 'false' ?>
+    const coordinates = <?= !empty($options['coordinates']) ? "'" . $options['coordinates'] . "'" : 'false' ?>
 
-    const address = <?= isset($address) ? "'$address'" : 'false' ?>
+    const address = <?= !empty($address) ? "'$address'" : 'false' ?>
 
-    const maptype = <?= isset($maptype) ? "'$maptype'" : "'roadmap'" ?>
+    const maptype = <?= !empty($maptype) ? "'$maptype'" : "'roadmap'" ?>
 
     const zoom = parseInt("<?= $zoom ?>", 10)
-    const stylesJson = "<?= isset($options['styles']) ? $options['styles'] : '[]' ?>"
+    const stylesJson = "<?= !empty($options['styles']) ? $options['styles'] : '[]' ?>"
     const styles = maptype === 'roadmap' ? JSON.parse(stylesJson) : []
     const config = { marker, coordinates, address, maptype, zoom, styles }
 

--- a/templates/stripes/stripe-googlemap.php
+++ b/templates/stripes/stripe-googlemap.php
@@ -59,7 +59,7 @@ function buildMap(config) {
     const mapWrapEl = stripeEl.querySelector('.vssl-stripe--googlemap--map')
     const customMarker = 'https://s3.amazonaws.com/cdn.vssl.io/marker.png'
 
-    const map = new google.maps.Map(mapWrapEl[0], {
+    const map = new google.maps.Map(mapWrapEl, {
         center: config.coordinates,
         zoom: config.zoom,
         styles: config.styles,

--- a/templates/stripes/stripe-googlemap.php
+++ b/templates/stripes/stripe-googlemap.php
@@ -1,22 +1,7 @@
 <?php if ($address): ?>
 <div class="<?= $this->e($type, 'wrapperClasses') ?>">
     <div class="vssl-stripe-column">
-        <div class="vssl-stripe--googlemap--embed"
-            <?php if (isset($options['styles'])): ?>
-            data-styles="<?= $this->inlineJson($options['styles']) ?>"
-            <?php endif; ?>
-            <?php if (isset($options['marker'])): ?>
-            data-marker="<?= $options['marker'] ?>"
-            <?php endif; ?>
-            <?php if (isset($coordinates)): ?>
-            data-coordinates="<?= $this->inlineJson($coordinates) ?>"
-            <?php endif; ?>
-            <?php if (isset($address)): ?>
-            data-location="<?= $address ?>"
-            <?php endif; ?>
-            data-maptype="<?= isset($maptype) ? $maptype : 'roadmap' ?>"
-            data-zoom="<?= $zoom ?>"
-        >
+        <div class="vssl-stripe--googlemap--embed">
             <div id="map-<?= $weight ?>" class="vssl-stripe--googlemap--map">
                 <!-- JS-loaded map goes here -->
                 <noscript>
@@ -38,4 +23,70 @@
         </div>
     </div>
 </div>
+<script>
+const stripeEl = document.currentScript.previousElementSibling
+
+if (typeof google !== 'undefined') {
+    try {
+        initStripe()
+    } catch(e) {
+        console.error('Failed to initialize google map stripe', e)
+    }
+} else {
+    console.error('Google Maps API is not available in this script.')
+}
+
+function initStripe() {
+    const marker = <?= isset($options['marker']) ? "'" . $options['marker'] . "'" : 'false' ?>
+
+    const coordinates = <?= isset($options['coordinates']) ? "'" . $options['coordinates'] . "'" : 'false' ?>
+
+    const address = <?= isset($address) ? "'$address'" : 'false' ?>
+
+    const maptype = <?= isset($maptype) ? "'$maptype'" : "'roadmap'" ?>
+
+    const zoom = parseInt("<?= $zoom ?>", 10)
+    const stylesJson = "<?= isset($options['styles']) ? $options['styles'] : '[]' ?>"
+    const styles = maptype === 'roadmap' ? JSON.parse(stylesJson) : []
+    const config = { marker, coordinates, address, maptype, zoom, styles }
+
+    if (coordinates) buildMap(config)
+    else if (address) geocode(config)
+    else console.warn('No coordinates or address set for Google Maps API. Doing nothing.')
+}
+
+function buildMap(config) {
+    const mapWrapEl = stripeEl.querySelector('.vssl-stripe--googlemap--map')
+    const customMarker = 'https://s3.amazonaws.com/cdn.vssl.io/marker.png'
+
+    const map = new google.maps.Map(mapWrapEl[0], {
+        center: config.coordinates,
+        zoom: config.zoom,
+        styles: config.styles,
+        mapTypeId: config.maptype,
+        mapTypeControl: false
+    })
+    new google.maps.Marker({
+        map,
+        position: config.coordinates,
+        icon: config.marker || customMarker
+    })
+}
+
+function geocode(config) {
+    const geocoder = new google.maps.Geocoder
+    geocoder.geocode({ address: config.address }, (results, status) => {
+        if (status === 'OK' && results.length) {
+            config.coordinates = results[0].geometry.location
+            config.formatted_address = results[0].formatted_address
+            buildMap(config)
+        }
+    })
+}
+
+const embedEl = stripeEl.querySelector('.vssl-stripe--googlemap--embed')
+embedEl.addEventListener('click', function() {
+    this.classList.add('is-engaged')
+})
+</script>
 <?php endif; ?>


### PR DESCRIPTION
# Google Maps Stripe: Fix broken implementation

- previously, the template for the google map stripe assumed a jquery script was being loaded on the page to establish the api connection with Google Maps API and initialize the map from the stripe's data
- that script is no longer being used, so I added a small vanilla js script alongside the google map stripe template itself to load a map from the stripe data
<img width="975" alt="image" src="https://github.com/vssl/render/assets/10877197/a38c0c03-5bb2-42b8-9f62-6995de86cd72">
