### PR TITLE
Table Stripe

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -370,6 +370,39 @@ class Renderer
     }
 
     /**
+     * Process stripe-table data.
+     *
+     * @param  array $stripe array of data
+     * @return array
+     */
+    public function processStripeTable($stripe)
+    {
+        $stripe['caption'] = !empty($stripe['caption']['html'])
+            ? $this->inline($stripe['caption']["html"])
+            : null;
+        $stripe['hasHeadersInFirstRow'] = !empty($stripe['hasHeadersInFirstRow'])
+            ? $stripe['hasHeadersInFirstRow']
+            : false;
+        $stripe['hasHeadersInFirstColumn'] = !empty($stripe['hasHeadersInFirstColumn'])
+            ? $stripe['hasHeadersInFirstColumn']
+            : false;
+        $stripe['hasAlternatingRows'] = !empty($stripe['hasAlternatingRows'])
+            ? $stripe['hasAlternatingRows']
+            : false;
+
+        $dataset = $stripe['dataset'];
+        // Ensure each item in the dataset is an array
+        $dataset = !empty($dataset) && is_array($dataset) ? $dataset : [[]];
+        foreach ($dataset as $key => $value) {
+            if (!is_array($value)) {
+                $dataset[$key] = [];
+            }
+        }
+        $stripe['dataset'] = array_filter($dataset);
+        return $stripe;
+    }
+
+    /**
      * Render the current data.
      *
      * @return string

--- a/templates/stripes/stripe-table.php
+++ b/templates/stripes/stripe-table.php
@@ -1,0 +1,39 @@
+<div class="vssl-stripe-column">
+  <table>
+    <?php if (!empty($caption)): ?>
+      <caption><?= htmlspecialchars($caption) ?></caption>
+    <?php endif; ?>
+
+    <?php if ($headersInFirstRow && !$headersInFirstColumn): ?>
+      <thead>
+        <?php foreach ($dataset[0] as $index => $item): ?>
+          <th><?= $item ?></th>
+        <?php endforeach; ?>
+      </thead>
+    <?php endif; ?>
+
+    <tbody>
+      <?php if ($headersInFirstRow && $headersInFirstColumn): ?>
+        <tr>
+          <?php foreach ($dataset[0] as $index => $item): ?>
+            <th><?= $item ?></th>
+          <?php endforeach; ?>
+        </tr>
+      <?php endif; ?>
+
+      <?php
+        $rows = $headersInFirstRow ? array_slice($dataset, 1) : $dataset;
+        foreach ($rows as $rowIndex => $row):
+      ?>
+        <tr>
+          <?php foreach ($row as $index => $item): ?>
+            <?php $tag = ($index === 0 && $headersInFirstColumn) ? 'th' : 'td'; ?>
+            <<?= $tag ?>>
+              <?= $item ?>
+            </<?= $tag ?>>
+          <?php endforeach; ?>
+        </tr>
+      <?php endforeach; ?>
+    </tbody>
+  </table>
+</div>

--- a/templates/stripes/stripe-table.php
+++ b/templates/stripes/stripe-table.php
@@ -1,48 +1,54 @@
 <?php
 $caption = !empty($caption["html"]) ? $this->inline($caption["html"]) : null;
-$headersInFirstRow = !empty($headersInFirstRow) ? $headersInFirstRow : false;
-$headersInFirstColumn = !empty($headersInFirstColumn) ? $headersInFirstColumn : false;
+$hasHeadersInFirstRow = !empty($hasHeadersInFirstRow) ? $hasHeadersInFirstRow : false;
+$hasHeadersInFirstColumn = !empty($hasHeadersInFirstColumn) ? $hasHeadersInFirstColumn : false;
+$hasAlternatingRows = !empty($hasAlternatingRows) ? $hasAlternatingRows : false;
 
-// Ensure each item in the dataset is an array.
+// Ensure each item in the dataset is an array
 $dataset = !empty($dataset) && is_array($dataset) ? $dataset : [[]];
 foreach ($dataset as $key => $value) {
     if (!is_array($value)) {
         $dataset[$key] = [];
     }
 }
+$dataset = array_filter($dataset);
 ?>
 
-<div class="<?= $this->e($type, 'wrapperClasses') ?>">
+<?php if (!empty($dataset)) : ?>
+<div 
+  class="<?= $this->e($type, 'wrapperClasses') ?>"
+  data-has-alternating-rows="<?= $hasAlternatingRows ? 'true' : 'false' ?>"
+>
   <div class="vssl-stripe-column">
     <table>
       <?php if (!empty($caption)) : ?>
         <caption><?= $caption ?></caption>
       <?php endif; ?>
 
-      <?php if ($headersInFirstRow && !$headersInFirstColumn): ?>
+      <?php if ($hasHeadersInFirstRow && !$hasHeadersInFirstColumn): ?>
         <thead>
-          <?php foreach ($dataset[0] as $index => $item): ?>
+          <?php foreach ($dataset[0] as $item): ?>
             <th><?= $item ?></th>
           <?php endforeach; ?>
         </thead>
       <?php endif; ?>
 
       <tbody>
-        <?php if ($headersInFirstRow && $headersInFirstColumn): ?>
+        <?php if ($hasHeadersInFirstRow && $hasHeadersInFirstColumn): ?>
           <tr>
-            <?php foreach ($dataset[0] as $index => $item): ?>
+            <?php foreach ($dataset[0] as $item): ?>
               <th><?= $item ?></th>
             <?php endforeach; ?>
           </tr>
         <?php endif; ?>
 
         <?php
-          $rows = $headersInFirstRow ? array_slice($dataset, 1) : $dataset;
-          foreach ($rows as $rowIndex => $row):
+          $rows = $hasHeadersInFirstRow ? array_slice($dataset, 1) : $dataset;
+          foreach ($rows as $row):
         ?>
           <tr>
             <?php foreach ($row as $index => $item): ?>
-              <?php $tag = ($index === 0 && $headersInFirstColumn) ? 'th' : 'td'; ?>
+              <?php $tag = ($index === 0 && $hasHeadersInFirstColumn) ? 'th' : 'td'; ?>
               <<?= $tag ?>>
                 <?= $item ?>
               </<?= $tag ?>>
@@ -53,3 +59,4 @@ foreach ($dataset as $key => $value) {
     </table>
   </div>
 </div>
+<?php endif; ?>

--- a/templates/stripes/stripe-table.php
+++ b/templates/stripes/stripe-table.php
@@ -1,21 +1,5 @@
-<?php
-$caption = !empty($caption["html"]) ? $this->inline($caption["html"]) : null;
-$hasHeadersInFirstRow = !empty($hasHeadersInFirstRow) ? $hasHeadersInFirstRow : false;
-$hasHeadersInFirstColumn = !empty($hasHeadersInFirstColumn) ? $hasHeadersInFirstColumn : false;
-$hasAlternatingRows = !empty($hasAlternatingRows) ? $hasAlternatingRows : false;
-
-// Ensure each item in the dataset is an array
-$dataset = !empty($dataset) && is_array($dataset) ? $dataset : [[]];
-foreach ($dataset as $key => $value) {
-    if (!is_array($value)) {
-        $dataset[$key] = [];
-    }
-}
-$dataset = array_filter($dataset);
-?>
-
 <?php if (!empty($dataset)) : ?>
-<div 
+<div
   class="<?= $this->e($type, 'wrapperClasses') ?>"
   data-has-alternating-rows="<?= $hasAlternatingRows ? 'true' : 'false' ?>"
 >

--- a/templates/stripes/stripe-table.php
+++ b/templates/stripes/stripe-table.php
@@ -1,10 +1,22 @@
+<?php
+$caption = !empty($caption["html"]) ? $this->inline($caption["html"]) : null;
+$headersInFirstRow = !empty($headersInFirstRow) ? $headersInFirstRow : false;
+$headersInFirstColumn = !empty($headersInFirstColumn) ? $headersInFirstColumn : false;
+
+// Ensure each item in the dataset is an array.
+$dataset = !empty($dataset) && is_array($dataset) ? $dataset : [[]];
+foreach ($dataset as $key => $value) {
+    if (!is_array($value)) {
+        $dataset[$key] = [];
+    }
+}
+?>
+
 <div class="<?= $this->e($type, 'wrapperClasses') ?>">
   <div class="vssl-stripe-column">
     <table>
-      <?php if (!empty($caption['html'])): ?>
-        <caption>
-          <?= $this->inline($caption['html']) ?>
-        </caption>
+      <?php if (!empty($caption)) : ?>
+        <caption><?= $caption ?></caption>
       <?php endif; ?>
 
       <?php if ($headersInFirstRow && !$headersInFirstColumn): ?>

--- a/templates/stripes/stripe-table.php
+++ b/templates/stripes/stripe-table.php
@@ -1,39 +1,43 @@
-<div class="vssl-stripe-column">
-  <table>
-    <?php if (!empty($caption)): ?>
-      <caption><?= htmlspecialchars($caption) ?></caption>
-    <?php endif; ?>
+<div class="<?= $this->e($type, 'wrapperClasses') ?>">
+  <div class="vssl-stripe-column">
+    <table>
+      <?php if (!empty($caption['html'])): ?>
+        <caption>
+          <?= $this->inline($caption['html']) ?>
+        </caption>
+      <?php endif; ?>
 
-    <?php if ($headersInFirstRow && !$headersInFirstColumn): ?>
-      <thead>
-        <?php foreach ($dataset[0] as $index => $item): ?>
-          <th><?= $item ?></th>
-        <?php endforeach; ?>
-      </thead>
-    <?php endif; ?>
-
-    <tbody>
-      <?php if ($headersInFirstRow && $headersInFirstColumn): ?>
-        <tr>
+      <?php if ($headersInFirstRow && !$headersInFirstColumn): ?>
+        <thead>
           <?php foreach ($dataset[0] as $index => $item): ?>
             <th><?= $item ?></th>
           <?php endforeach; ?>
-        </tr>
+        </thead>
       <?php endif; ?>
 
-      <?php
-        $rows = $headersInFirstRow ? array_slice($dataset, 1) : $dataset;
-        foreach ($rows as $rowIndex => $row):
-      ?>
-        <tr>
-          <?php foreach ($row as $index => $item): ?>
-            <?php $tag = ($index === 0 && $headersInFirstColumn) ? 'th' : 'td'; ?>
-            <<?= $tag ?>>
-              <?= $item ?>
-            </<?= $tag ?>>
-          <?php endforeach; ?>
-        </tr>
-      <?php endforeach; ?>
-    </tbody>
-  </table>
+      <tbody>
+        <?php if ($headersInFirstRow && $headersInFirstColumn): ?>
+          <tr>
+            <?php foreach ($dataset[0] as $index => $item): ?>
+              <th><?= $item ?></th>
+            <?php endforeach; ?>
+          </tr>
+        <?php endif; ?>
+
+        <?php
+          $rows = $headersInFirstRow ? array_slice($dataset, 1) : $dataset;
+          foreach ($rows as $rowIndex => $row):
+        ?>
+          <tr>
+            <?php foreach ($row as $index => $item): ?>
+              <?php $tag = ($index === 0 && $headersInFirstColumn) ? 'th' : 'td'; ?>
+              <<?= $tag ?>>
+                <?= $item ?>
+              </<?= $tag ?>>
+            <?php endforeach; ?>
+          </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
 </div>


### PR DESCRIPTION
Updated to include a new Table stripe (`./templates/stripes/stripe-table.php`), which will render table of data in a semantic `<table>` element.

<img width="293" alt="image" src="https://github.com/vssl/render/assets/10877197/5e428371-4622-4f0f-8f40-f014013bacb4">

In this PR
- New template for a table with configurable headers in the first row and/or column
- Handle cases where the dataset for the table might be empty or malformed
