### PR TITLE
Reference Stripe 

### DIFF
--- a/templates/page.php
+++ b/templates/page.php
@@ -3,7 +3,8 @@
     <div class="vssl-stripes">
         <?php foreach ($stripes as $index => $stripe) : ?>
             <?php $stripe['stripe_index'] = $index; ?>
-            <?= $this->insert($themePrefix . 'stripes/' . $stripe['type'], $stripe) ?>
+            <?php $stripe['template_name'] = $themePrefix . 'stripes/' . $stripe['type'] ?>
+            <?= $this->insert($stripe['template_name'], $stripe) ?>
         <?php endforeach; ?>
     </div>
     <?php endif; ?>

--- a/templates/stripes/stripe-reference--default.php
+++ b/templates/stripes/stripe-reference--default.php
@@ -1,0 +1,29 @@
+
+<div class="vssl-stripe-column">
+  <div class="vssl-stripe--related--link">
+    <a href="<?= $referencePage['slug'] ?>" target="_blank">
+      <?php if (!empty($referencePage['image'])) : ?>
+        <img
+          class="vssl-stripe--related--thumbnail"
+          src="<?= $this->image($referencePage['image'], !empty($image_style) ? $image_style : null) ?>"
+          alt="<?= $referencePage['image'] ?>"
+          loading="lazy"
+        />
+      <?php endif; ?>
+
+      <div class="vssl-stripe--related--text">
+        <div class="vssl-stripe--related--page-info">
+          <h3 class="vssl-stripe--related--title">
+            <?= $referencePage['title'] ?>
+          </h3>
+          <p class="vssl-stripe--related--description">
+            <?= $referencePage['summary'] ?>
+          </p>
+        </div>
+        <p class="vssl-stripe--related--url">
+          <?= $_SERVER['SERVER_NAME'] . $referencePage['slug'] ?>
+        </p>
+      </div>
+    </a>
+  </div>
+</div>

--- a/templates/stripes/stripe-reference--default.php
+++ b/templates/stripes/stripe-reference--default.php
@@ -1,26 +1,26 @@
 
 <div class="vssl-stripe-column">
-  <div class="vssl-stripe--related--link">
+  <div class="vssl-stripe--reference--link">
     <a href="<?= $referencePage['slug'] ?>" target="_blank">
       <?php if (!empty($referencePage['image'])) : ?>
         <img
-          class="vssl-stripe--related--thumbnail"
+          class="vssl-stripe--reference--thumbnail"
           src="<?= $this->image($referencePage['image'], !empty($image_style) ? $image_style : null) ?>"
           alt="<?= $referencePage['image'] ?>"
           loading="lazy"
         />
       <?php endif; ?>
 
-      <div class="vssl-stripe--related--text">
-        <div class="vssl-stripe--related--page-info">
-          <h3 class="vssl-stripe--related--title">
+      <div class="vssl-stripe--reference--text">
+        <div class="vssl-stripe--reference--page-info">
+          <h3 class="vssl-stripe--reference--title">
             <?= $referencePage['title'] ?>
           </h3>
-          <p class="vssl-stripe--related--description">
+          <p class="vssl-stripe--reference--description">
             <?= $referencePage['summary'] ?>
           </p>
         </div>
-        <p class="vssl-stripe--related--url">
+        <p class="vssl-stripe--reference--url">
           <?= $_SERVER['SERVER_NAME'] . $referencePage['slug'] ?>
         </p>
       </div>

--- a/templates/stripes/stripe-reference.php
+++ b/templates/stripes/stripe-reference.php
@@ -1,9 +1,9 @@
 <?php if (!empty($referencePage)) : ?>
-<?php $reference_type_template = $template_name . '--' . $referencePage['type']; ?>
+<?php $referenceTypeTemplate = $template_name . '--' . $referencePage['type']; ?>
 <div class="<?= $this->e($type, 'wrapperClasses') ?>">
   <?php
-  if ($this->engine->exists("$reference_type_template")) {
-    $this->insert($reference_type_template, get_defined_vars());
+  if ($this->engine->exists("$referenceTypeTemplate")) {
+    $this->insert($referenceTypeTemplate, get_defined_vars());
   } else {
     $this->insert("$template_name--default", get_defined_vars());
   }

--- a/templates/stripes/stripe-reference.php
+++ b/templates/stripes/stripe-reference.php
@@ -5,7 +5,7 @@
   if ($this->engine->exists("$referenceTypeTemplate")) {
     $this->insert($referenceTypeTemplate, get_defined_vars());
   } else {
-    $this->insert("$template_name--default", get_defined_vars());
+    $this->insert($template_name . '--default', get_defined_vars());
   }
   ?>
 </div>

--- a/templates/stripes/stripe-reference.php
+++ b/templates/stripes/stripe-reference.php
@@ -1,0 +1,12 @@
+<?php if (!empty($referencePage)) : ?>
+<?php $reference_type_template = $template_name . '--' . $referencePage['type']; ?>
+<div class="<?= $this->e($type, 'wrapperClasses') ?>">
+  <?php
+  if ($this->engine->exists("$reference_type_template")) {
+    $this->insert($reference_type_template, get_defined_vars());
+  } else {
+    $this->insert("$template_name--default", get_defined_vars());
+  }
+  ?>
+</div>
+<?php endif; ?>


### PR DESCRIPTION
- Added a new template for Reference type stripes at `./templates/stripes/stripe-reference.php`
- The template will dynamically look for any other theme templates suffixed with `--` and the type of the page being referenced (ex: `./template/stripes/stripe-reference--contact.php` for a template for referenced contact pages) but default to the `./template/stripes/stripe-reference--default.php` template if none is found.