### PR TITLE
Remove token exp cookie

### DIFF
--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -58,7 +58,12 @@ class Resolver
     public function setAuthHeaders()
     {
         $authToken = $_COOKIE['vssl-token'] ?? null;
-        $authExpiry = $_COOKIE['vssl-token-exp'] ?? null;
+        if (!empty($authToken)) {
+            $tokenParts = explode('.', $authToken);
+            $payload = base64_decode($tokenParts[1]);
+            $payloadData = json_decode($payload, true);
+            $authExpiry = $payloadData['exp'] ?? 0;
+        }
 
         $this->config['isAuthenticated'] = !empty($authToken)
             && !empty($authExpiry)

--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -60,7 +60,7 @@ class Resolver
         $authToken = $_COOKIE['vssl-token'] ?? null;
         if (!empty($authToken)) {
             $tokenParts = explode('.', $authToken);
-            $payload = base64_decode($tokenParts[1]);
+            $payload = !empty($tokenParts[1]) ? base64_decode($tokenParts[1]) : '{}';
             $payloadData = json_decode($payload, true);
             $authExpiry = $payloadData['exp'] ?? 0;
         }


### PR DESCRIPTION
- We don't need to use the expiration time cookie (exp is included in the token already) and depending on the client to set the expiration timestamp correctly can lead to issues
